### PR TITLE
Add CODEOWNERS file for repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# About CODEOWNERS - <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners>
+
+* @coliff


### PR DESCRIPTION
This pull request makes a small update to the `.github/CODEOWNERS` file, assigning repository ownership to the user `@coliff`.