### PR TITLE
Fix malformed HTML IDs; bump dev dependencies

### DIFF
--- a/js-sample-app/index.html
+++ b/js-sample-app/index.html
@@ -142,7 +142,7 @@
               <button class="accordion-button collapsed layer-select" type="button" id="trafficLayerHeader"
                 data-bs-toggle="collapse" data-bs-target="#trafficLayer" aria-expanded="true"
                 aria-controls="trafficLayer">
-                <h4 class="mb-0 d-inline" id="collapsible-group-item-1 trafficLayerTitle">
+                <h4 class="mb-0 d-inline" id="collapsible-group-item-1">
                   Traffic
                 </h4>
                 <div class="supporting-label"></div>
@@ -177,7 +177,7 @@
               <button class="accordion-button collapsed layer-select" type="button" id="weatherRadarHeader"
                 data-bs-toggle="collapse" data-bs-target="#weatherRadar" aria-expanded="false"
                 aria-controls="weatherRadar">
-                <h4 class="mb-0 d-inline" id="collapsible-group-item-2 weatherRadarTitle">
+                <h4 class="mb-0 d-inline" id="collapsible-group-item-2">
                   Weather Radar
                 </h4>
                 <div class="supporting-label"></div>
@@ -197,7 +197,7 @@
               <button class="accordion-button collapsed layer-select" type="button" id="weatherAlertsHeader"
                 data-bs-toggle="collapse" data-bs-target="#weatherAlerts" aria-expanded="false"
                 aria-controls="weatherAlerts">
-                <h4 class="mb-0 d-inline" id="collapsible-group-item-3 weatherAlertsTitle">
+                <h4 class="mb-0 d-inline" id="collapsible-group-item-3">
                   Weather Alerts
                 </h4>
                 <div class="supporting-label"></div>
@@ -227,7 +227,7 @@
               <button class="accordion-button collapsed layer-select" type="button" id="roadSurfaceHeader"
                 data-bs-toggle="collapse" data-bs-target="#roadSurface" aria-expanded="false"
                 aria-controls="roadSurface">
-                <h4 class="mb-0 d-inline" id="collapsible-group-item-4 roadSurfaceTitle">
+                <h4 class="mb-0 d-inline" id="collapsible-group-item-4">
                   Road Surface
                 </h4>
                 <div class="supporting-label"></div>
@@ -246,7 +246,7 @@
             <div class="accordion-header">
               <button class="accordion-button collapsed layer-select" type="button" id="placesHeader"
                 data-bs-toggle="collapse" data-bs-target="#places" aria-expanded="false" aria-controls="places">
-                <h4 class="mb-0 d-inline" id="collapsible-group-item-5 placesTitle">
+                <h4 class="mb-0 d-inline" id="collapsible-group-item-5">
                   Places
                 </h4>
                 <div class="supporting-label"></div>
@@ -281,7 +281,7 @@
               <button class="accordion-button collapsed layer-select" type="button" id="poiHeader"
                 data-bs-toggle="collapse" data-bs-target="#pointsOfInterest" aria-expanded="false"
                 aria-controls="pointsOfInterest">
-                <h4 class="mb-0 d-inline" id="collapsible-group-item-6 poiTitle">
+                <h4 class="mb-0 d-inline" id="collapsible-group-item-6">
                   Points of Interest
                 </h4>
                 <div class="supporting-label"></div>
@@ -310,7 +310,7 @@
             <div class="accordion-header">
               <button class="accordion-button collapsed layer-select" type="button" id="buildingsHeader"
                 data-bs-toggle="collapse" data-bs-target="#buildings" aria-expanded="false" aria-controls="buildings">
-                <h4 class="mb-0 d-inline" id="collapsible-group-item-7 buildingsTitle">
+                <h4 class="mb-0 d-inline" id="collapsible-group-item-7">
                   3D Buildings
                 </h4>
                 <div class="supporting-label"></div>
@@ -331,7 +331,7 @@
               <button class="accordion-button collapsed layer-select" type="button" id="trafficIncidentHeader"
                 data-bs-toggle="collapse" data-bs-target="#trafficIncident" aria-expanded="false"
                 aria-controls="trafficIncident">
-                <h4 class="mb-0 d-inline" id="collapsible-group-item-8 trafficIncidentTitle">
+                <h4 class="mb-0 d-inline" id="collapsible-group-item-8">
                   Traffic Incidents
                 </h4>
                 <div class="supporting-label"></div>
@@ -358,7 +358,7 @@
               <button class="accordion-button collapsed layer-select" type="button" id="truckRestrictionsHeader"
                 data-bs-toggle="collapse" data-bs-target="#truckRestrictions" aria-expanded="false"
                 aria-controls="truckRestrictions">
-                <h4 class="mb-0 d-inline" id="collapsible-group-item-9 truckRestrictionsTitle">
+                <h4 class="mb-0 d-inline" id="collapsible-group-item-9">
                   Truck Restrictions
                 </h4>
                 <div class="supporting-label"></div>
@@ -378,7 +378,7 @@
               <button class="accordion-button collapsed layer-select" type="button" id="customContentHeader"
                 data-bs-toggle="collapse" data-bs-target="#customContent" aria-expanded="false"
                 aria-controls="customContent">
-                <h4 class="mb-0 d-inline" id="collapsible-group-item-10 customContentTitle">
+                <h4 class="mb-0 d-inline" id="collapsible-group-item-10">
                   Custom Content
                 </h4>
                 <div class="supporting-label"></div>

--- a/react-js-sample-app/package.json
+++ b/react-js-sample-app/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@trimble-oss/modus-bootstrap": "^2.3.2",
-    "@types/react": "^18.3.23",
+    "@types/react": "^18.3.31",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^4.5.2",
     "eslint": "8.57.1",
@@ -37,7 +37,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.24",
     "sass": "~1.96.0",
-    "vite": "^5.4.19"
+    "vite": "^6.4.2"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
- Remove space-separated tokens from h4 id attributes in js-sample-app/index.html to ensure valid/unique IDs (e.g. "collapsible-group-item-1"), improving DOM selection and accessibility.
- Also update devDependencies in react-js-sample-app/package.json: bump @types/react to ^18.3.31 and vite to ^6.4.2.